### PR TITLE
Crossplatform way of producing the cache paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,12 @@
 /// <reference path="typings/typescript/typescript.d.ts"/>
 /// <reference path="typings/chalk/chalk.d.ts"/>
 /// <reference path="typings/node/node.d.ts"/>
+/// <reference path="typings/sanitize-filename/sanitize-filename.d.ts"/>
 import chalk = require("chalk");
 import fs = require("fs");
+import os = require("os");
 import path = require("path");
+import sanitize = require("sanitize-filename");
 import typescript = require("typescript");
 
 /**
@@ -55,9 +58,25 @@ function useCache(): boolean {
  */
 var defaultCompilerOptions: typescript.CompilerOptions = {
     module: typescript.ModuleKind.CommonJS,
-    outDir: path.join(path.sep, "tmp", "typescript-register", process.cwd()),
+    outDir: getCachePath(process.cwd()),
     target: typescript.ScriptTarget.ES5
 };
+
+/**
+ * Returns path to cache for source directory.
+ * @param  {string} directory Directory with source code
+ * @return {string}           Path with all special characters replaced with _ and
+ *                            prepended path to temporary directory 
+ */
+function getCachePath(directory: string): string {
+    var sanitizeOptions = {
+        replacement: "_"
+    };
+    var parts = directory.split(path.sep).map((p) => sanitize(p, sanitizeOptions));
+    var cachePath = path.join.apply(null, parts);
+
+    return path.join(os.tmpdir(), "typescript-register", cachePath);
+}
 
 /**
  * Checks the environment for JSON stringified compiler options. By default it

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "compile": "tsc index.ts test/spec.ts --module commonjs --noImplicitAny",
     "coverage": "cat ./coverage/lcov.info | coveralls",
-    "test": "istanbul cover _mocha",
+    "test": "istanbul cover node_modules/mocha/bin/_mocha",
     "typings": "tsd reinstall"
   },
   "repository": {
@@ -38,6 +38,7 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
+    "sanitize-filename": "^1.3.0",
     "tsd": "^0.6.0-beta.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/pspeter3/typescript-register",
   "dependencies": {
     "chalk": "^0.5.1",
+    "sanitize-filename": "^1.3.0",
     "typescript": "^1.4.1"
   },
   "devDependencies": {
@@ -38,7 +39,6 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
-    "sanitize-filename": "^1.3.0",
     "tsd": "^0.6.0-beta.5"
   }
 }

--- a/tsd.json
+++ b/tsd.json
@@ -19,6 +19,9 @@
     },
     "typescript/typescript.d.ts": {
       "commit": "ed38db403a56da84731a6f77b545762ee477a45b"
+    },
+    "sanitize-filename/sanitize-filename.d.ts": {
+      "commit": "b3834d886a95789e6ab56e8244775ec10c5293d0"
     }
   }
 }


### PR DESCRIPTION
Fixes #6.

I've also changed the test script so it works on Windows, see https://github.com/gotwarlost/istanbul/issues/90 for details. Please check if it still works for you.

Also I had the following two test failures on my Windows machine:

```
2 failing

  1) typescript-register useCache should not use the cache if configured:
     AssertionError: expected 978 to be close to 500 +/- 300
      at Context.<anonymous> (D:\X-Files\Projects\typescript-register\test\spec.js:76:20)

  2) typescript-register useCache should check for cache invalidations:
     AssertionError: expected 1317 to be close to 0 +/- 10
      at Context.<anonymous> (D:\X-Files\Projects\typescript-register\test\spec.js:85:20)
```

But they maybe linked to overall FS performance and not really failures. Anyway, please check tests before merging this request.
