### PR TITLE
Update to new TypeScript API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-/// <reference path="typings/typescript/typescript.d.ts"/>
 /// <reference path="typings/chalk/chalk.d.ts"/>
 /// <reference path="typings/node/node.d.ts"/>
 /// <reference path="typings/sanitize-filename/sanitize-filename.d.ts"/>
@@ -66,7 +65,7 @@ var defaultCompilerOptions: typescript.CompilerOptions = {
  * Returns path to cache for source directory.
  * @param  {string} directory Directory with source code
  * @return {string}           Path with all special characters replaced with _ and
- *                            prepended path to temporary directory 
+ *                            prepended path to temporary directory
  */
 function getCachePath(directory: string): string {
     var sanitizeOptions = {
@@ -139,12 +138,14 @@ function isModified(tsPath: string, jsPath: string): boolean {
 function compile(filename: string, options: typescript.CompilerOptions): void {
     var host = typescript.createCompilerHost(options);
     var program = typescript.createProgram([filename], options, host);
-    var checker = program.getTypeChecker(true);
-    var result = checker.emitFiles();
+    var result = program.emit();
     if (emitError()) {
-        checkErrors(program.getDiagnostics()
-            .concat(checker.getDiagnostics()
-            .concat(result.diagnostics)));
+        checkErrors(program.getOptionsDiagnostics()
+            .concat(program.getGlobalDiagnostics())
+            .concat(program.getSyntacticDiagnostics())
+            .concat(program.getSemanticDiagnostics())
+            .concat(program.getDeclarationDiagnostics())
+            .concat(result.diagnostics));
     }
 }
 
@@ -158,11 +159,11 @@ function checkErrors(errors: typescript.Diagnostic[]): void {
         return;
     }
     errors.forEach((diagnostic: typescript.Diagnostic): void => {
-        var position = diagnostic.file.getLineAndCharacterFromPosition(
+        var position = diagnostic.file.getLineAndCharacterOfPosition(
             diagnostic.start);
         console.error(
             chalk.bgRed("" + diagnostic.code),
-            chalk.grey(`${diagnostic.file.filename}, (${position.line},${position.character})`),
+            chalk.grey(`${diagnostic.file.fileName}, (${position.line},${position.character})`),
             diagnostic.messageText);
     });
     throw new Error("TypeScript Compilation Errors");

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "sanitize-filename": "^1.3.0",
-    "typescript": "^1.4.1"
+    "typescript": "^1.6"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -1,4 +1,3 @@
-/// <reference path="../typings/typescript/typescript.d.ts"/>
 /// <reference path="../typings/chai/chai.d.ts"/>
 /// <reference path="../typings/mocha/mocha.d.ts"/>
 /// <reference path="../typings/node/node.d.ts"/>

--- a/tsd.json
+++ b/tsd.json
@@ -17,9 +17,6 @@
     "node/node.d.ts": {
       "commit": "42c8a3b74c05f6887ce21dd63c6234e424f9f8fe"
     },
-    "typescript/typescript.d.ts": {
-      "commit": "ed38db403a56da84731a6f77b545762ee477a45b"
-    },
     "sanitize-filename/sanitize-filename.d.ts": {
       "commit": "b3834d886a95789e6ab56e8244775ec10c5293d0"
     }


### PR DESCRIPTION
This will close #14. It fixes some bugs with the newest TypeScript compiler.

Also note that it now implicitly uses the d.ts files embedded in the TypeScript instead of the ones from tsd (because the tsd ones were outdated).
